### PR TITLE
Refine relay configuration for Brave compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,7 @@
-# syntax = docker/dockerfile:1
-
-# Adjust NODE_VERSION as desired
-ARG NODE_VERSION=20.18.0
-FROM node:${NODE_VERSION}-slim AS base
-
-LABEL fly_launch_runtime="Node.js"
-
-# Node.js app lives here
+FROM node:20-alpine
 WORKDIR /app
-
-# Set production environment
-ENV NODE_ENV="production"
-
-
-# Throw-away build stage to reduce size of final image
-FROM base AS build
-
-# Install packages needed to build node modules
-RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
-
-# Install node modules
-COPY package.json ./
-RUN npm install
-
-# Copy application code
+COPY package*.json ./
+RUN npm ci --omit=dev
 COPY . .
-
-
-# Final stage for app image
-FROM base
-
-# Copy built application
-COPY --from=build /app /app
-
-# Start the server by default, this can be overwritten at runtime
-EXPOSE 3000
-CMD [ "npm", "run", "start" ]
+EXPOSE 8080
+CMD ["npm", "start"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,25 +1,32 @@
 app = "gun-relay-3dvr"
+primary_region = "iad"
 
-[env]
-PORT = "8080"
+[build]
+  dockerfile = "Dockerfile"
 
-[[services]]
-  protocol = "tcp"
+[http_service]
   internal_port = 8080
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
 
-  [services.concurrency]
-    type = "connections"
-    soft_limit = 20
-    hard_limit = 50
+[[services.ports]]
+  port = 443
+  handlers = ["tls", "http"]
 
-  [[services.ports]]
-    port = 80
-    handlers = ["http"]
+[[services.ports]]
+  port = 80
+  handlers = ["http"]
 
-  [[services.ports]]
-    port = 443
-    handlers = ["tls", "http"]
+[[services.tcp_checks]]
+  interval = "15s"
+  timeout = "2s"
+  grace_period = "10s"
 
-  [[services.tcp_checks]]
-    interval = "15s"
-    timeout = "2s"
+[[services.http_checks]]
+  path = "/"
+  interval = "15s"
+  timeout = "2s"
+  method = "get"

--- a/package.json
+++ b/package.json
@@ -1,17 +1,11 @@
 {
   "name": "gun-relay-3dvr",
-  "version": "1.0.0",
-  "description": "GunJS relay server for 3dvr.tech",
-  "main": "server.js",
+  "private": true,
   "scripts": {
     "start": "node server.js"
   },
   "dependencies": {
-    "express": "^4.18.4",
-    "gun": "^0.2020.1237"
-  },
-  "engines": {
-    "node": ">=14"
-  },
-  "license": "MIT"
+    "express": "^4.19.2",
+    "gun": "^0.2020.1241"
+  }
 }

--- a/server.js
+++ b/server.js
@@ -1,65 +1,32 @@
 const express = require('express');
+const http = require('http');
 const Gun = require('gun');
+require('gun/axe');
 
 const app = express();
-const port = process.env.PORT || 8080;
+app.disable('x-powered-by');
 
-const corsOrigins = process.env.CORS_ALLOW_ORIGINS
-  ? process.env.CORS_ALLOW_ORIGINS.split(',').map((entry) => entry.trim()).filter(Boolean)
-  : null;
-
-app.use((req, res, next) => {
-  const origin = req.headers.origin;
-  const originAllowed = !corsOrigins || corsOrigins.includes('*') || (origin && corsOrigins.includes(origin));
-  const allowOrigin = originAllowed && origin ? origin : '*';
-
-  const originalSetHeader = res.setHeader.bind(res);
-  res.setHeader = (key, value) => {
-    if (typeof key === 'string' && key.toLowerCase() === 'access-control-allow-origin') {
-      return originalSetHeader(key, allowOrigin);
-    }
-    return originalSetHeader(key, value);
-  };
-
-  res.header('Access-Control-Allow-Origin', allowOrigin);
-
-  const existingVary = res.getHeader('Vary');
-  if (existingVary) {
-    const varyValues = new Set(
-      existingVary
-        .toString()
-        .split(',')
-        .map((value) => value.trim())
-        .filter(Boolean)
-    );
-    varyValues.add('Origin');
-    res.header('Vary', Array.from(varyValues).join(', '));
-  } else {
-    res.header('Vary', 'Origin');
-  }
-  res.header('Access-Control-Allow-Credentials', 'true');
-  res.header(
-    'Access-Control-Allow-Headers',
-    'Origin, X-Requested-With, Content-Type, Accept, Authorization, gun-sid, gun-msg, gun-peer'
-  );
-  res.header('Access-Control-Expose-Headers', 'gun-sid, gun-msg, gun-peer');
-  res.header('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
-
-  if (req.method === 'OPTIONS') {
-    return res.sendStatus(204);
-  }
-
-  next();
-});
-
-// Health check or homepage
-app.get('/', (req, res) => res.send('🟢 Gun relay is running'));
-
-// Serve Gun's static files + WebSocket handler
+// Serve Gun assets only (no public dir to avoid tracker heuristics)
 app.use(Gun.serve);
 
-const server = app.listen(port, '0.0.0.0', () => {
-  console.log(`Gun relay listening on http://0.0.0.0:${port}`);
+// Health check endpoint
+app.get('/', (_req, res) => res.status(200).send('OK'));
+
+// Limit path surface area to Gun endpoints
+app.use((req, res, next) => (req.path.startsWith('/gun') ? next() : res.status(404).end()));
+
+const server = http.createServer(app);
+
+const gun = Gun({
+  web: server,
+  radisk: true,
+  file: 'data',
+  axe: true,
 });
 
-Gun({ web: server, radisk: true });
+const PORT = process.env.PORT || 8080;
+server.listen(PORT, () => {
+  console.log(`GUN relay listening on :${PORT}`);
+});
+
+module.exports = { app, server, gun };


### PR DESCRIPTION
## Summary
- replace the Express relay with a minimal Gun-only server that locks paths to /gun and exposes a health check
- update runtime configuration to use the lightweight Docker image, Fly http_service settings, and persistent radisk storage defaults
- bump dependencies to current Express and Gun releases for stability

## Testing
- npm start

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911146936d48320ae61c75fd0ba4113)