### PR TITLE
Add bounded Companion command relay

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,17 +1,38 @@
 # gun-relay-3dvr
 
-Gun relay server used by the 3dvr portal. The server now applies a Brave-friendly CORS policy that exposes Gun-specific headers
-and supports credentialed requests by reflecting the caller's origin.
+Private 3DVR relay used by the portal and 3DVR Companion. It provides the Gun sync endpoint plus short-lived, memory-only relay primitives for encrypted messages and permissioned device commands.
 
 ## Configuration
 
-- `PORT`: Port the Express server listens on (defaults to `8080`).
-- `CORS_ALLOW_ORIGINS`: Optional comma-separated list of allowed origins. Include `*` to mirror any origin. When unset, the
-  server reflects any provided origin.
+- `PORT`: Express listen port (defaults to `8080`).
+- `CORS_ALLOW_ORIGINS`: Optional comma-separated list of allowed origins.
+- `RELAY_TTL_MS`: Lifetime for one-time encrypted envelopes.
+- `RELAY_DEVICE_TTL_MS`: Lifetime for ephemeral Companion device credentials.
+- `COMPANION_AGENT_TOKEN`: Private server-side bearer token required to enqueue Companion commands and read their results. Never commit this value or expose it to the Android app.
+
+## Companion command relay
+
+The first direct-control slice deliberately permits only read-only capabilities:
+
+- `health`
+- `device.status`
+
+Flow:
+
+1. Companion bootstraps an ephemeral device id/token with `POST /relay/v1/devices`.
+2. The authorized agent queues a short-lived command with `POST /relay/v1/commands`.
+3. Companion polls `GET /relay/v1/devices/:deviceId/commands/next` using its device id and bearer credential.
+4. Companion posts the result to `POST /relay/v1/devices/:deviceId/results`.
+5. The agent reads the result once from `GET /relay/v1/results/:requestId`.
+
+Commands expire quickly, request ids are deduplicated, queues are bounded, results are device-bound, and all state is memory-only. The server refuses agent command access entirely when `COMPANION_AGENT_TOKEN` is not configured.
+
+This is intentionally not a remote shell. Additional Companion capabilities should be admitted one named capability at a time after the read-only round trip and device ownership/pairing are proven.
 
 ## Development
 
 ```bash
 npm install
+npm test
 npm start
 ```

--- a/companion-command-relay.js
+++ b/companion-command-relay.js
@@ -33,10 +33,12 @@ function createCompanionCommandRelay(options = {}) {
     randomToken = (bytes = 18) => crypto.randomBytes(bytes).toString('base64url'),
     agentToken = process.env.COMPANION_AGENT_TOKEN || '',
     hasDevice,
+    listDevices = () => [],
     authorizeDevice,
   } = options;
 
   if (typeof hasDevice !== 'function') throw new TypeError('hasDevice is required');
+  if (typeof listDevices !== 'function') throw new TypeError('listDevices must be a function');
   if (typeof authorizeDevice !== 'function') throw new TypeError('authorizeDevice is required');
 
   const queues = new Map();
@@ -184,6 +186,17 @@ function createCompanionCommandRelay(options = {}) {
   }
 
   function mount(app, { json, privateHeaders, allowRate }) {
+    app.get('/relay/v1/devices', (req, res) => {
+      privateHeaders(res);
+      if (!allowRate(req, 'companion-agent-devices', 120, 60 * 1000)) {
+        return res.status(429).json({ ok: false, error: 'rate limited' });
+      }
+      const auth = authorizeAgent(req);
+      if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+      cleanup();
+      return res.status(200).json({ ok: true, devices: listDevices() });
+    });
+
     app.post('/relay/v1/commands', json, (req, res) => {
       privateHeaders(res);
       if (!allowRate(req, 'companion-agent-command', 120, 60 * 1000)) {

--- a/companion-command-relay.js
+++ b/companion-command-relay.js
@@ -1,0 +1,288 @@
+'use strict';
+
+const crypto = require('crypto');
+
+const DEVICE_ID_RE = /^[A-Za-z0-9_-]{22,86}$/;
+const REQUEST_ID_RE = /^[A-Za-z0-9_-]{16,86}$/;
+const ALLOWED_CAPABILITIES = new Set(['health', 'device.status']);
+const MAX_COMMAND_TTL_MS = 60 * 1000;
+const DEFAULT_COMMAND_TTL_MS = 15 * 1000;
+const RESULT_TTL_MS = 2 * 60 * 1000;
+const MAX_QUEUE_PER_DEVICE = 32;
+const MAX_ARGUMENT_BYTES = 8 * 1024;
+const MAX_RESULT_BYTES = 24 * 1024;
+
+function tokenDigest(value) {
+  return crypto.createHash('sha256').update(String(value)).digest();
+}
+
+function safeTokenEqual(left, right) {
+  if (!left || !right) return false;
+  return crypto.timingSafeEqual(tokenDigest(left), tokenDigest(right));
+}
+
+function readBearer(req) {
+  const header = req.get('authorization') || '';
+  const match = /^Bearer\s+([^\s]{32,256})$/.exec(header);
+  return match ? match[1] : '';
+}
+
+function createCompanionCommandRelay(options = {}) {
+  const {
+    now = () => Date.now(),
+    randomToken = (bytes = 18) => crypto.randomBytes(bytes).toString('base64url'),
+    agentToken = process.env.COMPANION_AGENT_TOKEN || '',
+    hasDevice,
+    authorizeDevice,
+  } = options;
+
+  if (typeof hasDevice !== 'function') throw new TypeError('hasDevice is required');
+  if (typeof authorizeDevice !== 'function') throw new TypeError('authorizeDevice is required');
+
+  const queues = new Map();
+  const knownRequests = new Map();
+  const results = new Map();
+
+  function cleanup() {
+    const t = now();
+    for (const [deviceId, queue] of queues) {
+      const live = queue.filter((command) => command.expiresAt > t);
+      if (live.length) queues.set(deviceId, live);
+      else queues.delete(deviceId);
+    }
+    for (const [requestId, record] of knownRequests) {
+      if (record.expiresAt <= t) knownRequests.delete(requestId);
+    }
+    for (const [requestId, record] of results) {
+      if (record.expiresAt <= t) results.delete(requestId);
+    }
+  }
+
+  function authorizeAgent(req) {
+    if (!agentToken) return { ok: false, status: 503, error: 'agent relay unavailable' };
+    const supplied = readBearer(req);
+    if (!supplied || !safeTokenEqual(supplied, agentToken)) {
+      return { ok: false, status: 401, error: 'agent authorization required' };
+    }
+    return { ok: true };
+  }
+
+  function normalizeCommand(body = {}) {
+    const deviceId = typeof body.deviceId === 'string' ? body.deviceId.trim() : '';
+    const capabilityId = typeof body.capabilityId === 'string' ? body.capabilityId.trim() : '';
+    const requestedId = typeof body.requestId === 'string' ? body.requestId.trim() : '';
+    const requestId = requestedId || randomToken(18);
+    const argumentsValue = body.arguments == null ? {} : body.arguments;
+
+    if (!DEVICE_ID_RE.test(deviceId)) throw new Error('invalid device id');
+    if (!REQUEST_ID_RE.test(requestId)) throw new Error('invalid request id');
+    if (!ALLOWED_CAPABILITIES.has(capabilityId)) throw new Error('unsupported capability');
+    if (!argumentsValue || typeof argumentsValue !== 'object' || Array.isArray(argumentsValue)) {
+      throw new Error('arguments must be an object');
+    }
+    if (Buffer.byteLength(JSON.stringify(argumentsValue), 'utf8') > MAX_ARGUMENT_BYTES) {
+      throw new Error('arguments too large');
+    }
+
+    const ttlRaw = Number(body.ttlMs);
+    const ttlMs = Number.isFinite(ttlRaw)
+      ? Math.min(MAX_COMMAND_TTL_MS, Math.max(1000, Math.round(ttlRaw)))
+      : DEFAULT_COMMAND_TTL_MS;
+    const createdAt = now();
+    return {
+      requestId,
+      deviceId,
+      capabilityId,
+      arguments: argumentsValue,
+      createdAt,
+      expiresAt: createdAt + ttlMs,
+    };
+  }
+
+  function enqueue(command) {
+    cleanup();
+    if (knownRequests.has(command.requestId)) throw new Error('duplicate request id');
+    const queue = queues.get(command.deviceId) || [];
+    if (queue.length >= MAX_QUEUE_PER_DEVICE) throw new Error('device queue full');
+    queue.push(command);
+    queues.set(command.deviceId, queue);
+    knownRequests.set(command.requestId, {
+      deviceId: command.deviceId,
+      state: 'queued',
+      expiresAt: command.expiresAt,
+    });
+  }
+
+  function takeNext(deviceId) {
+    cleanup();
+    const queue = queues.get(deviceId) || [];
+    while (queue.length) {
+      const command = queue.shift();
+      if (command.expiresAt <= now()) continue;
+      if (queue.length) queues.set(deviceId, queue);
+      else queues.delete(deviceId);
+      knownRequests.set(command.requestId, {
+        deviceId,
+        state: 'inflight',
+        expiresAt: command.expiresAt,
+      });
+      return command;
+    }
+    queues.delete(deviceId);
+    return null;
+  }
+
+  function acceptResult(deviceId, body = {}) {
+    cleanup();
+    const requestId = typeof body.requestId === 'string' ? body.requestId.trim() : '';
+    if (!REQUEST_ID_RE.test(requestId)) throw new Error('invalid request id');
+    if (typeof body.ok !== 'boolean') throw new Error('ok must be boolean');
+    const known = knownRequests.get(requestId);
+    if (!known || known.deviceId !== deviceId || known.state !== 'inflight') {
+      throw new Error('request is not inflight for this device');
+    }
+    const code = typeof body.code === 'string' ? body.code.slice(0, 120) : null;
+    const data = body.data == null ? {} : body.data;
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      throw new Error('data must be an object');
+    }
+    if (Buffer.byteLength(JSON.stringify(data), 'utf8') > MAX_RESULT_BYTES) {
+      throw new Error('result too large');
+    }
+    const completedAt = now();
+    results.set(requestId, {
+      response: {
+        ok: true,
+        requestId,
+        commandOk: body.ok,
+        code,
+        data,
+        completedAt,
+      },
+      expiresAt: completedAt + RESULT_TTL_MS,
+    });
+    knownRequests.set(requestId, {
+      deviceId,
+      state: 'completed',
+      expiresAt: completedAt + RESULT_TTL_MS,
+    });
+  }
+
+  function resultStatus(requestId) {
+    cleanup();
+    const result = results.get(requestId);
+    if (result) {
+      results.delete(requestId);
+      knownRequests.delete(requestId);
+      return { status: 200, body: result.response };
+    }
+    const known = knownRequests.get(requestId);
+    if (known) {
+      return { status: 202, body: { ok: true, requestId, state: known.state } };
+    }
+    return { status: 404, body: { ok: false, error: 'request not found' } };
+  }
+
+  function mount(app, { json, privateHeaders, allowRate }) {
+    app.post('/relay/v1/commands', json, (req, res) => {
+      privateHeaders(res);
+      if (!allowRate(req, 'companion-agent-command', 120, 60 * 1000)) {
+        return res.status(429).json({ ok: false, error: 'rate limited' });
+      }
+      const auth = authorizeAgent(req);
+      if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+
+      try {
+        const command = normalizeCommand(req.body || {});
+        if (!hasDevice(command.deviceId)) {
+          return res.status(404).json({ ok: false, error: 'device not available' });
+        }
+        enqueue(command);
+        return res.status(201).json({
+          ok: true,
+          requestId: command.requestId,
+          deviceId: command.deviceId,
+          capabilityId: command.capabilityId,
+          createdAt: command.createdAt,
+          expiresAt: command.expiresAt,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'invalid command';
+        const status = message === 'device queue full' ? 429 : 400;
+        return res.status(status).json({ ok: false, error: message });
+      }
+    });
+
+    app.get('/relay/v1/devices/:deviceId/commands/next', (req, res) => {
+      privateHeaders(res);
+      if (!allowRate(req, 'companion-device-poll', 600, 60 * 1000)) {
+        return res.status(429).json({ ok: false, error: 'rate limited' });
+      }
+      const auth = authorizeDevice(req);
+      if (!auth || auth.id !== req.params.deviceId) {
+        return res.status(401).json({ ok: false, error: 'device authorization required' });
+      }
+      const command = takeNext(auth.id);
+      return res.status(200).json({
+        ok: true,
+        command: command
+          ? {
+              requestId: command.requestId,
+              capabilityId: command.capabilityId,
+              arguments: command.arguments,
+              issuedAt: command.createdAt,
+              expiresAt: command.expiresAt,
+            }
+          : null,
+      });
+    });
+
+    app.post('/relay/v1/devices/:deviceId/results', json, (req, res) => {
+      privateHeaders(res);
+      if (!allowRate(req, 'companion-device-result', 240, 60 * 1000)) {
+        return res.status(429).json({ ok: false, error: 'rate limited' });
+      }
+      const auth = authorizeDevice(req);
+      if (!auth || auth.id !== req.params.deviceId) {
+        return res.status(401).json({ ok: false, error: 'device authorization required' });
+      }
+      try {
+        acceptResult(auth.id, req.body || {});
+        return res.status(202).json({ ok: true, requestId: req.body.requestId });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'invalid result';
+        return res.status(400).json({ ok: false, error: message });
+      }
+    });
+
+    app.get('/relay/v1/results/:requestId', (req, res) => {
+      privateHeaders(res);
+      if (!allowRate(req, 'companion-agent-result', 240, 60 * 1000)) {
+        return res.status(429).json({ ok: false, error: 'rate limited' });
+      }
+      const auth = authorizeAgent(req);
+      if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+      if (!REQUEST_ID_RE.test(req.params.requestId || '')) {
+        return res.status(404).json({ ok: false, error: 'request not found' });
+      }
+      const result = resultStatus(req.params.requestId);
+      return res.status(result.status).json(result.body);
+    });
+  }
+
+  return {
+    mount,
+    cleanup,
+    normalizeCommand,
+    enqueue,
+    takeNext,
+    acceptResult,
+    resultStatus,
+    authorizeAgent,
+  };
+}
+
+module.exports = {
+  ALLOWED_CAPABILITIES,
+  createCompanionCommandRelay,
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "gun-relay-3dvr",
   "private": true,
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "express": "^4.19.2",

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const http = require('http');
 const crypto = require('crypto');
 const Gun = require('gun');
 require('gun/axe');
+const { createCompanionCommandRelay } = require('./companion-command-relay');
 
 const app = express();
 app.disable('x-powered-by');
@@ -170,6 +171,14 @@ function validateReplyEnvelope(value) {
 }
 
 const relayJson = express.json({ limit: '32kb', type: 'application/json' });
+const companionCommands = createCompanionCommandRelay({
+  hasDevice: (deviceId) => {
+    cleanup();
+    return devices.has(deviceId);
+  },
+  authorizeDevice: authorizedDevice,
+});
+companionCommands.mount(app, { json: relayJson, privateHeaders, allowRate });
 
 // Serve Gun assets only (no public dir to avoid tracker heuristics)
 app.use(Gun.serve);
@@ -187,6 +196,7 @@ app.get('/relay/v1/health', (req, res) => {
     oneTimeReads: true,
     ttlMs: RELAY_TTL_MS,
     keyId: relayKeyId,
+    companionCommands: ['health', 'device.status'],
   });
 });
 

--- a/server.js
+++ b/server.js
@@ -8,14 +8,8 @@ const { createCompanionCommandRelay } = require('./companion-command-relay');
 const app = express();
 app.disable('x-powered-by');
 
-const RELAY_TTL_MS = Math.min(
-  5 * 60 * 1000,
-  Math.max(30 * 1000, Number.parseInt(process.env.RELAY_TTL_MS || '120000', 10) || 120000),
-);
-const DEVICE_TTL_MS = Math.min(
-  24 * 60 * 60 * 1000,
-  Math.max(5 * 60 * 1000, Number.parseInt(process.env.RELAY_DEVICE_TTL_MS || '3600000', 10) || 3600000),
-);
+const RELAY_TTL_MS = Math.min(5 * 60 * 1000, Math.max(30 * 1000, Number.parseInt(process.env.RELAY_TTL_MS || '120000', 10) || 120000));
+const DEVICE_TTL_MS = Math.min(24 * 60 * 60 * 1000, Math.max(5 * 60 * 1000, Number.parseInt(process.env.RELAY_DEVICE_TTL_MS || '3600000', 10) || 3600000));
 const MAX_ENVELOPES = 128;
 const MAX_PAYLOAD_BYTES = 24 * 1024;
 const REF_RE = /^[A-Za-z0-9_-]{22,86}$/;
@@ -24,43 +18,23 @@ const envelopes = new Map();
 const devices = new Map();
 const rateBuckets = new Map();
 
-const { publicKey: relayPublicKey, privateKey: relayPrivateKey } = crypto.generateKeyPairSync('rsa', {
-  modulusLength: 3072,
-  publicExponent: 0x10001,
-});
+const { publicKey: relayPublicKey, privateKey: relayPrivateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 3072, publicExponent: 0x10001 });
 const relayPublicPem = relayPublicKey.export({ type: 'spki', format: 'pem' });
-const relayKeyId = crypto
-  .createHash('sha256')
-  .update(relayPublicKey.export({ type: 'spki', format: 'der' }))
-  .digest('hex')
-  .slice(0, 24);
+const relayKeyId = crypto.createHash('sha256').update(relayPublicKey.export({ type: 'spki', format: 'der' })).digest('hex').slice(0, 24);
 
-function now() {
-  return Date.now();
-}
-
-function randomToken(bytes = 32) {
-  return crypto.randomBytes(bytes).toString('base64url');
-}
-
-function sha256(value) {
-  return crypto.createHash('sha256').update(String(value)).digest();
-}
-
+function now() { return Date.now(); }
+function randomToken(bytes = 32) { return crypto.randomBytes(bytes).toString('base64url'); }
+function sha256(value) { return crypto.createHash('sha256').update(String(value)).digest(); }
 function safeEqual(left, right) {
-  if (!Buffer.isBuffer(left) || !Buffer.isBuffer(right) || left.length !== right.length) {
-    return false;
-  }
+  if (!Buffer.isBuffer(left) || !Buffer.isBuffer(right) || left.length !== right.length) return false;
   return crypto.timingSafeEqual(left, right);
 }
-
 function privateHeaders(res) {
   res.setHeader('Cache-Control', 'no-store, max-age=0');
   res.setHeader('Pragma', 'no-cache');
   res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive');
   res.setHeader('Referrer-Policy', 'no-referrer');
 }
-
 function clientIp(req) {
   const fly = req.get('fly-client-ip');
   if (fly) return fly;
@@ -68,260 +42,112 @@ function clientIp(req) {
   if (forwarded) return forwarded.split(',')[0].trim();
   return req.socket?.remoteAddress || 'unknown';
 }
-
 function allowRate(req, namespace, limit, windowMs) {
   const key = `${namespace}:${clientIp(req)}`;
   const t = now();
   let bucket = rateBuckets.get(key);
-  if (!bucket || bucket.resetAt <= t) {
-    bucket = { count: 0, resetAt: t + windowMs };
-    rateBuckets.set(key, bucket);
-  }
+  if (!bucket || bucket.resetAt <= t) { bucket = { count: 0, resetAt: t + windowMs }; rateBuckets.set(key, bucket); }
   bucket.count += 1;
   return bucket.count <= limit;
 }
-
 function cleanup() {
   const t = now();
-  for (const [ref, item] of envelopes) {
-    if (item.expiresAt <= t) envelopes.delete(ref);
-  }
-  for (const [id, item] of devices) {
-    if (item.expiresAt <= t) devices.delete(id);
-  }
-  for (const [key, item] of rateBuckets) {
-    if (item.resetAt <= t) rateBuckets.delete(key);
-  }
+  for (const [ref, item] of envelopes) if (item.expiresAt <= t) envelopes.delete(ref);
+  for (const [id, item] of devices) if (item.expiresAt <= t) devices.delete(id);
+  for (const [key, item] of rateBuckets) if (item.resetAt <= t) rateBuckets.delete(key);
 }
-
-const cleanupTimer = setInterval(cleanup, 30 * 1000);
-cleanupTimer.unref?.();
-
+const cleanupTimer = setInterval(cleanup, 30 * 1000); cleanupTimer.unref?.();
 function createEnvelope(kind, payload, direction) {
   cleanup();
   if (envelopes.size >= MAX_ENVELOPES) {
     const oldest = [...envelopes.entries()].sort((a, b) => a[1].createdAt - b[1].createdAt)[0];
     if (oldest) envelopes.delete(oldest[0]);
   }
-  const ref = randomToken(32);
-  const createdAt = now();
-  const expiresAt = createdAt + RELAY_TTL_MS;
+  const ref = randomToken(32); const createdAt = now(); const expiresAt = createdAt + RELAY_TTL_MS;
   envelopes.set(ref, { kind, payload, direction, createdAt, expiresAt });
   return { ref, createdAt, expiresAt };
 }
-
 function readBearer(req) {
   const header = req.get('authorization') || '';
   const match = /^Bearer\s+([A-Za-z0-9_-]{32,128})$/.exec(header);
   return match ? match[1] : '';
 }
-
 function authorizedDevice(req) {
-  const id = req.get('x-3dvr-device') || '';
-  const token = readBearer(req);
+  const id = req.get('x-3dvr-device') || ''; const token = readBearer(req);
   if (!REF_RE.test(id) || !token) return null;
   const record = devices.get(id);
-  if (!record || record.expiresAt <= now()) {
-    devices.delete(id);
-    return null;
-  }
+  if (!record || record.expiresAt <= now()) { devices.delete(id); return null; }
   return safeEqual(record.tokenHash, sha256(token)) ? { id, record } : null;
 }
-
 function parseHybridEnvelope(encoded) {
-  if (typeof encoded !== 'string' || encoded.length < 40 || encoded.length > 12000) {
-    throw new Error('invalid encrypted envelope');
-  }
+  if (typeof encoded !== 'string' || encoded.length < 40 || encoded.length > 12000) throw new Error('invalid encrypted envelope');
   const outer = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
-  if (!outer || typeof outer !== 'object') throw new Error('invalid encrypted envelope');
-  if (outer.v !== 1 || outer.kid !== relayKeyId) throw new Error('wrong relay key');
-
-  const wrappedKey = Buffer.from(String(outer.k || ''), 'base64url');
-  const iv = Buffer.from(String(outer.iv || ''), 'base64url');
-  const tag = Buffer.from(String(outer.tag || ''), 'base64url');
-  const ciphertext = Buffer.from(String(outer.ct || ''), 'base64url');
-  if (wrappedKey.length < 256 || iv.length !== 12 || tag.length !== 16 || ciphertext.length < 1) {
-    throw new Error('invalid encrypted envelope');
-  }
-
-  const aesKey = crypto.privateDecrypt(
-    {
-      key: relayPrivateKey,
-      oaepHash: 'sha256',
-      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
-    },
-    wrappedKey,
-  );
+  if (!outer || typeof outer !== 'object' || outer.v !== 1 || outer.kid !== relayKeyId) throw new Error('invalid encrypted envelope');
+  const wrappedKey = Buffer.from(String(outer.k || ''), 'base64url'); const iv = Buffer.from(String(outer.iv || ''), 'base64url');
+  const tag = Buffer.from(String(outer.tag || ''), 'base64url'); const ciphertext = Buffer.from(String(outer.ct || ''), 'base64url');
+  if (wrappedKey.length < 256 || iv.length !== 12 || tag.length !== 16 || ciphertext.length < 1) throw new Error('invalid encrypted envelope');
+  const aesKey = crypto.privateDecrypt({ key: relayPrivateKey, oaepHash: 'sha256', padding: crypto.constants.RSA_PKCS1_OAEP_PADDING }, wrappedKey);
   if (aesKey.length !== 32) throw new Error('invalid encrypted key');
-
-  const decipher = crypto.createDecipheriv('aes-256-gcm', aesKey, iv);
-  decipher.setAuthTag(tag);
+  const decipher = crypto.createDecipheriv('aes-256-gcm', aesKey, iv); decipher.setAuthTag(tag);
   return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
 }
-
 function validateReplyEnvelope(value) {
   if (!value || typeof value !== 'object' || value.kind !== 'message.reply') return null;
-  const payload = value.payload;
-  if (!payload || typeof payload !== 'object') return null;
-  const key = typeof payload.key === 'string' ? payload.key.trim() : '';
-  const text = typeof payload.text === 'string' ? payload.text : '';
-  if (!key || !text.trim()) return null;
-  if (Buffer.byteLength(key, 'utf8') > 1024 || Buffer.byteLength(text, 'utf8') > 4000) return null;
+  const payload = value.payload; if (!payload || typeof payload !== 'object') return null;
+  const key = typeof payload.key === 'string' ? payload.key.trim() : ''; const text = typeof payload.text === 'string' ? payload.text : '';
+  if (!key || !text.trim() || Buffer.byteLength(key, 'utf8') > 1024 || Buffer.byteLength(text, 'utf8') > 4000) return null;
   return { key, text };
 }
 
 const relayJson = express.json({ limit: '32kb', type: 'application/json' });
 const companionCommands = createCompanionCommandRelay({
-  hasDevice: (deviceId) => {
-    cleanup();
-    return devices.has(deviceId);
-  },
+  hasDevice: (deviceId) => { cleanup(); return devices.has(deviceId); },
+  listDevices: () => { cleanup(); return [...devices.entries()].map(([deviceId, record]) => ({ deviceId, expiresAt: record.expiresAt })); },
   authorizeDevice: authorizedDevice,
 });
 companionCommands.mount(app, { json: relayJson, privateHeaders, allowRate });
 
-// Serve Gun assets only (no public dir to avoid tracker heuristics)
 app.use(Gun.serve);
-
-// Health check endpoint
 app.get('/', (_req, res) => res.status(200).send('OK'));
-
 app.get('/relay/v1/health', (req, res) => {
-  privateHeaders(res);
-  cleanup();
-  res.status(200).json({
-    ok: true,
-    service: '3dvr-private-relay',
-    storage: 'memory-only',
-    oneTimeReads: true,
-    ttlMs: RELAY_TTL_MS,
-    keyId: relayKeyId,
-    companionCommands: ['health', 'device.status'],
-  });
+  privateHeaders(res); cleanup();
+  res.status(200).json({ ok: true, service: '3dvr-private-relay', storage: 'memory-only', oneTimeReads: true, ttlMs: RELAY_TTL_MS, keyId: relayKeyId, companionCommands: ['health', 'device.status'] });
 });
-
 app.get('/relay/v1/public-key', (req, res) => {
-  privateHeaders(res);
-  if (!allowRate(req, 'public-key', 60, 60 * 1000)) {
-    return res.status(429).json({ ok: false, error: 'rate limited' });
-  }
-  return res.status(200).json({
-    ok: true,
-    version: 1,
-    keyId: relayKeyId,
-    algorithm: 'RSA-OAEP-SHA256+A256GCM',
-    publicKeyPem: relayPublicPem,
-  });
+  privateHeaders(res); if (!allowRate(req, 'public-key', 60, 60 * 1000)) return res.status(429).json({ ok: false, error: 'rate limited' });
+  return res.status(200).json({ ok: true, version: 1, keyId: relayKeyId, algorithm: 'RSA-OAEP-SHA256+A256GCM', publicKeyPem: relayPublicPem });
 });
-
-// Device credentials are intentionally ephemeral. Companion can bootstrap a new
-// credential automatically after relay restarts; nothing is written to disk.
 app.post('/relay/v1/devices', relayJson, (req, res) => {
-  privateHeaders(res);
-  if (!allowRate(req, 'device-bootstrap', 12, 60 * 60 * 1000)) {
-    return res.status(429).json({ ok: false, error: 'rate limited' });
-  }
-  cleanup();
-  const id = randomToken(18);
-  const token = randomToken(32);
-  const expiresAt = now() + DEVICE_TTL_MS;
-  devices.set(id, { tokenHash: sha256(token), expiresAt });
-  return res.status(201).json({ ok: true, deviceId: id, deviceToken: token, expiresAt });
+  privateHeaders(res); if (!allowRate(req, 'device-bootstrap', 12, 60 * 60 * 1000)) return res.status(429).json({ ok: false, error: 'rate limited' });
+  cleanup(); const id = randomToken(18); const token = randomToken(32); const expiresAt = now() + DEVICE_TTL_MS;
+  devices.set(id, { tokenHash: sha256(token), expiresAt }); return res.status(201).json({ ok: true, deviceId: id, deviceToken: token, expiresAt });
 });
-
-// Phone -> agent. The caller must hold the short-lived device credential.
 app.post('/relay/v1/envelopes', relayJson, (req, res) => {
-  privateHeaders(res);
-  if (!allowRate(req, 'device-upload', 60, 60 * 1000)) {
-    return res.status(429).json({ ok: false, error: 'rate limited' });
-  }
-  if (!authorizedDevice(req)) {
-    return res.status(401).json({ ok: false, error: 'device authorization required' });
-  }
-  const body = req.body || {};
-  if (body.kind !== 'messages.snapshot' || !body.payload || typeof body.payload !== 'object') {
-    return res.status(400).json({ ok: false, error: 'unsupported envelope' });
-  }
-  const bytes = Buffer.byteLength(JSON.stringify(body.payload), 'utf8');
-  if (bytes > MAX_PAYLOAD_BYTES) {
-    return res.status(413).json({ ok: false, error: 'payload too large' });
-  }
-  const envelope = createEnvelope('messages.snapshot', body.payload, 'device-to-agent');
-  return res.status(201).json({ ok: true, ...envelope });
+  privateHeaders(res); if (!allowRate(req, 'device-upload', 60, 60 * 1000)) return res.status(429).json({ ok: false, error: 'rate limited' });
+  if (!authorizedDevice(req)) return res.status(401).json({ ok: false, error: 'device authorization required' });
+  const body = req.body || {}; if (body.kind !== 'messages.snapshot' || !body.payload || typeof body.payload !== 'object') return res.status(400).json({ ok: false, error: 'unsupported envelope' });
+  if (Buffer.byteLength(JSON.stringify(body.payload), 'utf8') > MAX_PAYLOAD_BYTES) return res.status(413).json({ ok: false, error: 'payload too large' });
+  const envelope = createEnvelope('messages.snapshot', body.payload, 'device-to-agent'); return res.status(201).json({ ok: true, ...envelope });
 });
-
-// Agent -> phone. The reply body reaches this endpoint only as authenticated
-// ciphertext. The resulting opaque ref is safe to carry through the audit bridge.
 app.get('/relay/v1/encrypted/:blob', (req, res) => {
-  privateHeaders(res);
-  if (!allowRate(req, 'encrypted-upload', 30, 60 * 1000)) {
-    return res.status(429).json({ ok: false, error: 'rate limited' });
-  }
+  privateHeaders(res); if (!allowRate(req, 'encrypted-upload', 30, 60 * 1000)) return res.status(429).json({ ok: false, error: 'rate limited' });
   try {
-    const plaintext = parseHybridEnvelope(req.params.blob);
-    if (plaintext.length > 8 * 1024) {
-      return res.status(413).json({ ok: false, error: 'payload too large' });
-    }
-    const parsed = JSON.parse(plaintext.toString('utf8'));
-    const payload = validateReplyEnvelope(parsed);
-    if (!payload) {
-      return res.status(400).json({ ok: false, error: 'unsupported envelope' });
-    }
-    const envelope = createEnvelope('message.reply', payload, 'agent-to-device');
-    return res.status(201).json({ ok: true, ...envelope });
-  } catch (_error) {
-    return res.status(400).json({ ok: false, error: 'invalid encrypted envelope' });
-  }
+    const plaintext = parseHybridEnvelope(req.params.blob); if (plaintext.length > 8 * 1024) return res.status(413).json({ ok: false, error: 'payload too large' });
+    const payload = validateReplyEnvelope(JSON.parse(plaintext.toString('utf8'))); if (!payload) return res.status(400).json({ ok: false, error: 'unsupported envelope' });
+    const envelope = createEnvelope('message.reply', payload, 'agent-to-device'); return res.status(201).json({ ok: true, ...envelope });
+  } catch (_error) { return res.status(400).json({ ok: false, error: 'invalid encrypted envelope' }); }
 });
-
-// Single-use read. The envelope is deleted before the response is written.
 app.get('/relay/v1/envelopes/:ref', (req, res) => {
-  privateHeaders(res);
-  if (!allowRate(req, 'envelope-read', 120, 60 * 1000)) {
-    return res.status(429).json({ ok: false, error: 'rate limited' });
-  }
-  const ref = req.params.ref || '';
-  if (!REF_RE.test(ref)) {
-    return res.status(404).json({ ok: false, error: 'not found' });
-  }
-  const envelope = envelopes.get(ref);
-  envelopes.delete(ref);
-  if (!envelope) {
-    return res.status(404).json({ ok: false, error: 'not found' });
-  }
-  if (envelope.expiresAt <= now()) {
-    return res.status(410).json({ ok: false, error: 'expired' });
-  }
-  return res.status(200).json({
-    ok: true,
-    kind: envelope.kind,
-    payload: envelope.payload,
-    direction: envelope.direction,
-    createdAt: envelope.createdAt,
-    expiresAt: envelope.expiresAt,
-    consumed: true,
-  });
+  privateHeaders(res); if (!allowRate(req, 'envelope-read', 120, 60 * 1000)) return res.status(429).json({ ok: false, error: 'rate limited' });
+  const ref = req.params.ref || ''; if (!REF_RE.test(ref)) return res.status(404).json({ ok: false, error: 'not found' });
+  const envelope = envelopes.get(ref); envelopes.delete(ref); if (!envelope) return res.status(404).json({ ok: false, error: 'not found' });
+  if (envelope.expiresAt <= now()) return res.status(410).json({ ok: false, error: 'expired' });
+  return res.status(200).json({ ok: true, kind: envelope.kind, payload: envelope.payload, direction: envelope.direction, createdAt: envelope.createdAt, expiresAt: envelope.expiresAt, consumed: true });
 });
-
-// Limit path surface area to Gun and private-relay endpoints.
-app.use((req, res, next) => (
-  req.path.startsWith('/gun') || req.path.startsWith('/relay/')
-    ? next()
-    : res.status(404).end()
-));
+app.use((req, res, next) => (req.path.startsWith('/gun') || req.path.startsWith('/relay/') ? next() : res.status(404).end()));
 
 const server = http.createServer(app);
-
-const gun = Gun({
-  web: server,
-  radisk: true,
-  file: 'data',
-  axe: true,
-});
-
+const gun = Gun({ web: server, radisk: true, file: 'data', axe: true });
 const PORT = process.env.PORT || 8080;
-server.listen(PORT, () => {
-  console.log(`GUN relay listening on :${PORT}`);
-});
-
+server.listen(PORT, () => { console.log(`GUN relay listening on :${PORT}`); });
 module.exports = { app, server, gun };

--- a/test/companion-command-relay.test.js
+++ b/test/companion-command-relay.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createCompanionCommandRelay } = require('../companion-command-relay');
+
+function createRelay({ agentToken = 'agent-token-abcdefghijklmnopqrstuvwxyz123456', start = 1_000_000 } = {}) {
+  let clock = start;
+  const devices = new Set(['device_abcdefghijklmnopqrstuv', 'device_zyxwvutsrqponmlkjihgfe']);
+  const relay = createCompanionCommandRelay({
+    now: () => clock,
+    randomToken: () => 'request_abcdefghijklmnopqrstuv',
+    agentToken,
+    hasDevice: (deviceId) => devices.has(deviceId),
+    authorizeDevice: () => null,
+  });
+  return {
+    relay,
+    devices,
+    advance(milliseconds) {
+      clock += milliseconds;
+    },
+  };
+}
+
+function fakeRequest(authorization) {
+  return {
+    get(name) {
+      return name.toLowerCase() === 'authorization' ? authorization || '' : '';
+    },
+  };
+}
+
+test('agent API is unavailable without a configured agent token', () => {
+  const { relay } = createRelay({ agentToken: '' });
+  assert.deepEqual(relay.authorizeAgent(fakeRequest()), {
+    ok: false,
+    status: 503,
+    error: 'agent relay unavailable',
+  });
+});
+
+test('agent API rejects an incorrect bearer token', () => {
+  const { relay } = createRelay();
+  assert.deepEqual(relay.authorizeAgent(fakeRequest('Bearer wrong-token-wrong-token-wrong-token-wrong-token')), {
+    ok: false,
+    status: 401,
+    error: 'agent authorization required',
+  });
+});
+
+test('agent API accepts the configured bearer token', () => {
+  const token = 'agent-token-abcdefghijklmnopqrstuvwxyz123456';
+  const { relay } = createRelay({ agentToken: token });
+  assert.deepEqual(relay.authorizeAgent(fakeRequest(`Bearer ${token}`)), { ok: true });
+});
+
+test('only read-only capabilities are admitted initially', () => {
+  const { relay } = createRelay();
+  assert.throws(
+    () => relay.normalizeCommand({
+      deviceId: 'device_abcdefghijklmnopqrstuv',
+      requestId: 'request_abcdefghijklmnopqrstuv',
+      capabilityId: 'ui.perform',
+    }),
+    /unsupported capability/,
+  );
+});
+
+test('command moves from queue to inflight to one-time result', () => {
+  const { relay } = createRelay();
+  const command = relay.normalizeCommand({
+    deviceId: 'device_abcdefghijklmnopqrstuv',
+    requestId: 'request_abcdefghijklmnopqrstuv',
+    capabilityId: 'device.status',
+    arguments: {},
+    ttlMs: 10_000,
+  });
+
+  relay.enqueue(command);
+  const delivered = relay.takeNext(command.deviceId);
+  assert.equal(delivered.requestId, command.requestId);
+  assert.equal(delivered.capabilityId, 'device.status');
+
+  assert.deepEqual(relay.resultStatus(command.requestId), {
+    status: 202,
+    body: { ok: true, requestId: command.requestId, state: 'inflight' },
+  });
+
+  relay.acceptResult(command.deviceId, {
+    requestId: command.requestId,
+    ok: true,
+    data: { batteryPercent: 67 },
+  });
+
+  const completed = relay.resultStatus(command.requestId);
+  assert.equal(completed.status, 200);
+  assert.equal(completed.body.ok, true);
+  assert.equal(completed.body.commandOk, true);
+  assert.deepEqual(completed.body.data, { batteryPercent: 67 });
+
+  assert.deepEqual(relay.resultStatus(command.requestId), {
+    status: 404,
+    body: { ok: false, error: 'request not found' },
+  });
+});
+
+test('duplicate request ids are rejected', () => {
+  const { relay } = createRelay();
+  const command = relay.normalizeCommand({
+    deviceId: 'device_abcdefghijklmnopqrstuv',
+    requestId: 'request_abcdefghijklmnopqrstuv',
+    capabilityId: 'health',
+  });
+  relay.enqueue(command);
+  assert.throws(() => relay.enqueue(command), /duplicate request id/);
+});
+
+test('expired queued commands are never delivered', () => {
+  const context = createRelay();
+  const command = context.relay.normalizeCommand({
+    deviceId: 'device_abcdefghijklmnopqrstuv',
+    requestId: 'request_abcdefghijklmnopqrstuv',
+    capabilityId: 'health',
+    ttlMs: 1_000,
+  });
+  context.relay.enqueue(command);
+  context.advance(1_001);
+  assert.equal(context.relay.takeNext(command.deviceId), null);
+});
+
+test('a different device cannot submit a result for an inflight request', () => {
+  const { relay } = createRelay();
+  const command = relay.normalizeCommand({
+    deviceId: 'device_abcdefghijklmnopqrstuv',
+    requestId: 'request_abcdefghijklmnopqrstuv',
+    capabilityId: 'health',
+  });
+  relay.enqueue(command);
+  relay.takeNext(command.deviceId);
+
+  assert.throws(
+    () => relay.acceptResult('device_zyxwvutsrqponmlkjihgfe', {
+      requestId: command.requestId,
+      ok: true,
+      data: {},
+    }),
+    /request is not inflight for this device/,
+  );
+});


### PR DESCRIPTION
## What changed
- adds a device-specific, memory-only command queue to the existing Fly/GUN relay
- keeps the initial direct-control surface limited to `health` and `device.status`
- uses the existing ephemeral Companion device credentials for device polling/results
- requires a separate server-side `COMPANION_AGENT_TOKEN` for agent command enqueue/result reads
- short TTLs, bounded per-device queues, request-id deduplication, cross-device result rejection, and one-time result reads
- adds Node 20 tests and GitHub Actions CI

## Why
This is the server half of replacing the slow GitHub/Termux polling path with the already-planned direct Companion relay. Termux remains fallback/recovery.

## Safety
No remote shell, no UI selectors/coordinates, no app launches, no URL opens, and no committed credentials. If `COMPANION_AGENT_TOKEN` is absent, the agent command surface is disabled.