### PR TITLE
Authenticate Companion agent commands with Vercel OIDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Private 3DVR relay used by the portal and 3DVR Companion. It provides the Gun sy
 - `CORS_ALLOW_ORIGINS`: Optional comma-separated list of allowed origins.
 - `RELAY_TTL_MS`: Lifetime for one-time encrypted envelopes.
 - `RELAY_DEVICE_TTL_MS`: Lifetime for ephemeral Companion device credentials.
-- `COMPANION_AGENT_TOKEN`: Private server-side bearer token required to enqueue Companion commands and read their results. Never commit this value or expose it to the Android app.
+
+No shared Companion agent password is required in production. Agent command routes verify Vercel's signed OIDC workload identity and accept only the production `3dvr/3dvr-portal` workload. The relay discovers Vercel's signing keys through the issuer's OpenID metadata/JWKS endpoints and caches public metadata briefly in memory.
 
 ## Companion command relay
 
@@ -20,12 +21,14 @@ The first direct-control slice deliberately permits only read-only capabilities:
 Flow:
 
 1. Companion bootstraps an ephemeral device id/token with `POST /relay/v1/devices`.
-2. The authorized agent queues a short-lived command with `POST /relay/v1/commands`.
+2. The production 3DVR Portal presents its Vercel OIDC token and queues a short-lived command with `POST /relay/v1/commands`.
 3. Companion polls `GET /relay/v1/devices/:deviceId/commands/next` using its device id and bearer credential.
 4. Companion posts the result to `POST /relay/v1/devices/:deviceId/results`.
-5. The agent reads the result once from `GET /relay/v1/results/:requestId`.
+5. The Portal reads the result once from `GET /relay/v1/results/:requestId`.
 
-Commands expire quickly, request ids are deduplicated, queues are bounded, results are device-bound, and all state is memory-only. The server refuses agent command access entirely when `COMPANION_AGENT_TOKEN` is not configured.
+The OIDC trust policy pins the team slug/id, project name/id, production environment, issuer, audience, subject, expiry, and RS256 signature. Preview deployments and other Vercel projects are rejected.
+
+Commands expire quickly, request ids are deduplicated, queues are bounded, results are device-bound, and all command/result state is memory-only.
 
 This is intentionally not a remote shell. Additional Companion capabilities should be admitted one named capability at a time after the read-only round trip and device ownership/pairing are proven.
 

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const Gun = require('gun');
 require('gun/axe');
 const { createCompanionCommandRelay } = require('./companion-command-relay');
+const { createVercelOidcAuthorizer } = require('./vercel-oidc');
 
 const app = express();
 app.disable('x-powered-by');
@@ -100,7 +101,35 @@ function validateReplyEnvelope(value) {
 }
 
 const relayJson = express.json({ limit: '32kb', type: 'application/json' });
+
+// Agent commands use Vercel workload identity rather than a shared secret.
+// Only the production 3dvr/3dvr-portal workload is admitted. After verification
+// the public OIDC token is replaced with a process-local bearer understood only
+// by the in-memory command module, so downstream code never needs to parse JWTs.
+const vercelOidc = createVercelOidcAuthorizer();
+const internalCompanionAgentToken = randomToken(32);
+function isCompanionAgentRoute(req) {
+  if (req.method === 'GET' && req.path === '/relay/v1/devices') return true;
+  if (req.method === 'POST' && req.path === '/relay/v1/commands') return true;
+  return req.method === 'GET' && req.path.startsWith('/relay/v1/results/');
+}
+app.use(async (req, res, next) => {
+  if (!isCompanionAgentRoute(req)) return next();
+  privateHeaders(res);
+  if (!allowRate(req, 'companion-agent-oidc', 300, 60 * 1000)) {
+    return res.status(429).json({ ok: false, error: 'rate limited' });
+  }
+  try {
+    await vercelOidc.authorizeRequest(req);
+    req.headers.authorization = `Bearer ${internalCompanionAgentToken}`;
+    return next();
+  } catch (_error) {
+    return res.status(401).json({ ok: false, error: 'workload identity required' });
+  }
+});
+
 const companionCommands = createCompanionCommandRelay({
+  agentToken: internalCompanionAgentToken,
   hasDevice: (deviceId) => { cleanup(); return devices.has(deviceId); },
   listDevices: () => { cleanup(); return [...devices.entries()].map(([deviceId, record]) => ({ deviceId, expiresAt: record.expiresAt })); },
   authorizeDevice: authorizedDevice,
@@ -111,7 +140,7 @@ app.use(Gun.serve);
 app.get('/', (_req, res) => res.status(200).send('OK'));
 app.get('/relay/v1/health', (req, res) => {
   privateHeaders(res); cleanup();
-  res.status(200).json({ ok: true, service: '3dvr-private-relay', storage: 'memory-only', oneTimeReads: true, ttlMs: RELAY_TTL_MS, keyId: relayKeyId, companionCommands: ['health', 'device.status'] });
+  res.status(200).json({ ok: true, service: '3dvr-private-relay', storage: 'memory-only', oneTimeReads: true, ttlMs: RELAY_TTL_MS, keyId: relayKeyId, companionCommands: ['health', 'device.status'], agentAuth: 'vercel-oidc' });
 });
 app.get('/relay/v1/public-key', (req, res) => {
   privateHeaders(res); if (!allowRate(req, 'public-key', 60, 60 * 1000)) return res.status(429).json({ ok: false, error: 'rate limited' });

--- a/test/vercel-oidc.test.js
+++ b/test/vercel-oidc.test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('crypto');
+const { createVercelOidcAuthorizer } = require('../vercel-oidc');
+
+const ISSUER = 'https://oidc.vercel.com/3dvr';
+const AUDIENCE = 'https://vercel.com/3dvr';
+const SUBJECT = 'owner:3dvr:project:3dvr-portal:environment:production';
+const NOW_MS = Date.UTC(2026, 7, 17, 18, 10, 0);
+const NOW_SECONDS = Math.floor(NOW_MS / 1000);
+
+function baseClaims(overrides = {}) {
+  return {
+    iss: ISSUER,
+    aud: AUDIENCE,
+    sub: SUBJECT,
+    iat: NOW_SECONDS - 30,
+    nbf: NOW_SECONDS - 30,
+    exp: NOW_SECONDS + 600,
+    owner: '3dvr',
+    owner_id: 'team_KXuVUd00RMnDsjoqwdREcZ7J',
+    project: '3dvr-portal',
+    project_id: 'prj_V49UqQXH0kmkYcL0NZFBkklzsbuy',
+    environment: 'production',
+    ...overrides,
+  };
+}
+
+function encode(value) {
+  return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
+}
+
+function signToken(privateKey, claims, kid = 'test-key') {
+  const header = encode({ typ: 'JWT', alg: 'RS256', kid });
+  const payload = encode(claims);
+  const signingInput = `${header}.${payload}`;
+  const signature = crypto.sign('RSA-SHA256', Buffer.from(signingInput, 'utf8'), privateKey).toString('base64url');
+  return `${signingInput}.${signature}`;
+}
+
+function fixture() {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const jwk = publicKey.export({ format: 'jwk' });
+  Object.assign(jwk, { kid: 'test-key', use: 'sig', alg: 'RS256' });
+  const calls = [];
+  const fetchImpl = async (url) => {
+    calls.push(String(url));
+    if (String(url) === `${ISSUER}/.well-known/openid-configuration`) {
+      return { ok: true, json: async () => ({ issuer: ISSUER, jwks_uri: `${ISSUER}/jwks` }) };
+    }
+    if (String(url) === `${ISSUER}/jwks`) {
+      return { ok: true, json: async () => ({ keys: [jwk] }) };
+    }
+    return { ok: false, status: 404, json: async () => ({}) };
+  };
+  const authorizer = createVercelOidcAuthorizer({ fetchImpl, now: () => NOW_MS });
+  return { authorizer, privateKey, calls };
+}
+
+test('accepts the exact production 3dvr-portal workload identity', async () => {
+  const { authorizer, privateKey } = fixture();
+  const identity = await authorizer.verify(signToken(privateKey, baseClaims()));
+  assert.deepEqual(identity, {
+    owner: '3dvr',
+    project: '3dvr-portal',
+    environment: 'production',
+    subject: SUBJECT,
+  });
+});
+
+test('rejects preview deployments even when signed by Vercel', async () => {
+  const { authorizer, privateKey } = fixture();
+  const token = signToken(privateKey, baseClaims({
+    sub: 'owner:3dvr:project:3dvr-portal:environment:preview',
+    environment: 'preview',
+  }));
+  await assert.rejects(() => authorizer.verify(token), /unexpected identity subject|unexpected identity environment/);
+});
+
+test('rejects another Vercel project', async () => {
+  const { authorizer, privateKey } = fixture();
+  const token = signToken(privateKey, baseClaims({
+    sub: 'owner:3dvr:project:donovan-lighting:environment:production',
+    project: 'donovan-lighting',
+    project_id: 'prj_other',
+  }));
+  await assert.rejects(() => authorizer.verify(token), /unexpected identity subject|unexpected identity project/);
+});
+
+test('rejects a tampered token signature', async () => {
+  const { authorizer, privateKey } = fixture();
+  const token = signToken(privateKey, baseClaims());
+  const parts = token.split('.');
+  const tampered = `${parts[0]}.${encode(baseClaims({ environment: 'preview' }))}.${parts[2]}`;
+  await assert.rejects(() => authorizer.verify(tampered), /invalid identity signature/);
+});
+
+test('rejects expired production tokens', async () => {
+  const { authorizer, privateKey } = fixture();
+  const token = signToken(privateKey, baseClaims({ exp: NOW_SECONDS - 120 }));
+  await assert.rejects(() => authorizer.verify(token), /expired identity token/);
+});
+
+test('caches discovery and JWKS metadata across successful verifications', async () => {
+  const { authorizer, privateKey, calls } = fixture();
+  const token = signToken(privateKey, baseClaims());
+  await authorizer.verify(token);
+  await authorizer.verify(token);
+  assert.equal(calls.filter((url) => url.includes('openid-configuration')).length, 1);
+  assert.equal(calls.filter((url) => url.endsWith('/jwks')).length, 1);
+});

--- a/vercel-oidc.js
+++ b/vercel-oidc.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const crypto = require('crypto');
+
+const MAX_TOKEN_BYTES = 16 * 1024;
+const DEFAULT_CACHE_MS = 10 * 60 * 1000;
+const CLOCK_TOLERANCE_SECONDS = 60;
+
+function decodeBase64UrlJson(value) {
+  const decoded = Buffer.from(value, 'base64url').toString('utf8');
+  return JSON.parse(decoded);
+}
+
+function audienceMatches(value, expected) {
+  if (typeof value === 'string') return value === expected;
+  return Array.isArray(value) && value.includes(expected);
+}
+
+function createVercelOidcAuthorizer(options = {}) {
+  const {
+    issuer = 'https://oidc.vercel.com/3dvr',
+    audience = 'https://vercel.com/3dvr',
+    subject = 'owner:3dvr:project:3dvr-portal:environment:production',
+    owner = '3dvr',
+    ownerId = 'team_KXuVUd00RMnDsjoqwdREcZ7J',
+    project = '3dvr-portal',
+    projectId = 'prj_V49UqQXH0kmkYcL0NZFBkklzsbuy',
+    environment = 'production',
+    fetchImpl = globalThis.fetch,
+    now = () => Date.now(),
+    cacheMs = DEFAULT_CACHE_MS,
+  } = options;
+
+  if (typeof fetchImpl !== 'function') throw new TypeError('fetch implementation is required');
+
+  let discoveryCache = null;
+  let jwksCache = null;
+
+  async function fetchJson(url) {
+    const response = await fetchImpl(url, {
+      headers: { accept: 'application/json' },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!response.ok) throw new Error(`identity metadata HTTP ${response.status}`);
+    return response.json();
+  }
+
+  async function discovery(force = false) {
+    const t = now();
+    if (!force && discoveryCache && discoveryCache.expiresAt > t) return discoveryCache.value;
+    const value = await fetchJson(`${issuer}/.well-known/openid-configuration`);
+    if (!value || value.issuer !== issuer || typeof value.jwks_uri !== 'string') {
+      throw new Error('invalid identity metadata');
+    }
+    discoveryCache = { value, expiresAt: t + cacheMs };
+    return value;
+  }
+
+  async function jwks(force = false) {
+    const t = now();
+    if (!force && jwksCache && jwksCache.expiresAt > t) return jwksCache.value;
+    const metadata = await discovery(force);
+    const value = await fetchJson(metadata.jwks_uri);
+    if (!value || !Array.isArray(value.keys)) throw new Error('invalid identity keys');
+    jwksCache = { value, expiresAt: t + cacheMs };
+    return value;
+  }
+
+  async function signingKey(kid) {
+    let keys = await jwks(false);
+    let jwk = keys.keys.find((key) => key && key.kid === kid);
+    if (!jwk) {
+      keys = await jwks(true);
+      jwk = keys.keys.find((key) => key && key.kid === kid);
+    }
+    if (!jwk || jwk.kty !== 'RSA' || (jwk.use && jwk.use !== 'sig') || (jwk.alg && jwk.alg !== 'RS256')) {
+      throw new Error('identity signing key unavailable');
+    }
+    return crypto.createPublicKey({ key: jwk, format: 'jwk' });
+  }
+
+  async function verify(token) {
+    if (typeof token !== 'string' || token.length < 64 || Buffer.byteLength(token, 'utf8') > MAX_TOKEN_BYTES) {
+      throw new Error('invalid identity token');
+    }
+    const parts = token.split('.');
+    if (parts.length !== 3 || parts.some((part) => !part)) throw new Error('invalid identity token');
+
+    let header;
+    let claims;
+    try {
+      header = decodeBase64UrlJson(parts[0]);
+      claims = decodeBase64UrlJson(parts[1]);
+    } catch (_error) {
+      throw new Error('invalid identity token');
+    }
+    if (!header || header.typ !== 'JWT' || header.alg !== 'RS256' || typeof header.kid !== 'string') {
+      throw new Error('unsupported identity token');
+    }
+
+    const key = await signingKey(header.kid);
+    const verified = crypto.verify(
+      'RSA-SHA256',
+      Buffer.from(`${parts[0]}.${parts[1]}`, 'utf8'),
+      key,
+      Buffer.from(parts[2], 'base64url'),
+    );
+    if (!verified) throw new Error('invalid identity signature');
+
+    const seconds = Math.floor(now() / 1000);
+    if (claims.iss !== issuer) throw new Error('unexpected identity issuer');
+    if (!audienceMatches(claims.aud, audience)) throw new Error('unexpected identity audience');
+    if (claims.sub !== subject) throw new Error('unexpected identity subject');
+    if (claims.owner !== owner || claims.owner_id !== ownerId) throw new Error('unexpected identity owner');
+    if (claims.project !== project || claims.project_id !== projectId) throw new Error('unexpected identity project');
+    if (claims.environment !== environment) throw new Error('unexpected identity environment');
+    if (!Number.isFinite(claims.exp) || claims.exp < seconds - CLOCK_TOLERANCE_SECONDS) {
+      throw new Error('expired identity token');
+    }
+    if (Number.isFinite(claims.nbf) && claims.nbf > seconds + CLOCK_TOLERANCE_SECONDS) {
+      throw new Error('identity token not active');
+    }
+    if (Number.isFinite(claims.iat) && claims.iat > seconds + CLOCK_TOLERANCE_SECONDS) {
+      throw new Error('identity token issued in the future');
+    }
+
+    return {
+      owner: claims.owner,
+      project: claims.project,
+      environment: claims.environment,
+      subject: claims.sub,
+    };
+  }
+
+  async function authorizeRequest(req) {
+    const header = req.get('authorization') || '';
+    const match = /^Bearer\s+([^\s]+)$/.exec(header);
+    if (!match) throw new Error('missing workload identity');
+    return verify(match[1]);
+  }
+
+  return { verify, authorizeRequest };
+}
+
+module.exports = { createVercelOidcAuthorizer };


### PR DESCRIPTION
## What changed
- removes the production shared-secret requirement from Companion agent command routes
- verifies Vercel RS256 OIDC tokens using the issuer's OpenID discovery + JWKS metadata
- pins identity to team `3dvr`, team id `team_KXuVUd00RMnDsjoqwdREcZ7J`, project `3dvr-portal`, project id `prj_V49UqQXH0kmkYcL0NZFBkklzsbuy`, and `production`
- validates issuer, audience, subject, signature, expiry, nbf, and iat
- rejects preview deployments and other Vercel projects
- replaces the verified external JWT with a random process-local bearer before entering the existing command module
- adds focused signature/claims/cache tests

## Why
This eliminates another human setup step: no Fly secret needs to be copied or maintained for the Portal→relay trust boundary.

## Safety
Device credentials are unchanged. The only remotely admitted Companion commands remain `health` and `device.status`.