### PR TITLE
Companion relay: admit bounded app and URL actions

### DIFF
--- a/companion-command-relay.js
+++ b/companion-command-relay.js
@@ -4,7 +4,17 @@ const crypto = require('crypto');
 
 const DEVICE_ID_RE = /^[A-Za-z0-9_-]{22,86}$/;
 const REQUEST_ID_RE = /^[A-Za-z0-9_-]{16,86}$/;
-const ALLOWED_CAPABILITIES = new Set(['health', 'device.status']);
+const ALLOWED_CAPABILITIES = new Set(['health', 'device.status', 'app.open_known', 'url.open']);
+const ALLOWED_APP_ALIASES = new Set([
+  'settings',
+  'chatgpt',
+  'maps',
+  'gmail',
+  'chrome',
+  'calendar',
+  'camera',
+  'messages',
+]);
 const MAX_COMMAND_TTL_MS = 60 * 1000;
 const DEFAULT_COMMAND_TTL_MS = 15 * 1000;
 const RESULT_TTL_MS = 2 * 60 * 1000;
@@ -25,6 +35,40 @@ function readBearer(req) {
   const header = req.get('authorization') || '';
   const match = /^Bearer\s+([^\s]{32,256})$/.exec(header);
   return match ? match[1] : '';
+}
+
+function normalizeArguments(capabilityId, value) {
+  const argumentsValue = value == null ? {} : value;
+  if (!argumentsValue || typeof argumentsValue !== 'object' || Array.isArray(argumentsValue)) {
+    throw new Error('arguments must be an object');
+  }
+  if (Buffer.byteLength(JSON.stringify(argumentsValue), 'utf8') > MAX_ARGUMENT_BYTES) {
+    throw new Error('arguments too large');
+  }
+
+  if (capabilityId === 'health' || capabilityId === 'device.status') {
+    if (Object.keys(argumentsValue).length !== 0) throw new Error('capability does not accept arguments');
+    return {};
+  }
+
+  if (capabilityId === 'app.open_known') {
+    const alias = typeof argumentsValue.alias === 'string' ? argumentsValue.alias.trim().toLowerCase() : '';
+    if (!ALLOWED_APP_ALIASES.has(alias)) throw new Error('unsupported app alias');
+    return { alias };
+  }
+
+  if (capabilityId === 'url.open') {
+    const raw = typeof argumentsValue.url === 'string' ? argumentsValue.url.trim() : '';
+    if (!raw || raw.length > 2048) throw new Error('valid https url required');
+    let parsed;
+    try { parsed = new URL(raw); } catch (_error) { throw new Error('valid https url required'); }
+    if (parsed.protocol !== 'https:' || parsed.username || parsed.password) {
+      throw new Error('valid https url required');
+    }
+    return { url: parsed.toString() };
+  }
+
+  throw new Error('unsupported capability');
 }
 
 function createCompanionCommandRelay(options = {}) {
@@ -74,17 +118,11 @@ function createCompanionCommandRelay(options = {}) {
     const capabilityId = typeof body.capabilityId === 'string' ? body.capabilityId.trim() : '';
     const requestedId = typeof body.requestId === 'string' ? body.requestId.trim() : '';
     const requestId = requestedId || randomToken(18);
-    const argumentsValue = body.arguments == null ? {} : body.arguments;
 
     if (!DEVICE_ID_RE.test(deviceId)) throw new Error('invalid device id');
     if (!REQUEST_ID_RE.test(requestId)) throw new Error('invalid request id');
     if (!ALLOWED_CAPABILITIES.has(capabilityId)) throw new Error('unsupported capability');
-    if (!argumentsValue || typeof argumentsValue !== 'object' || Array.isArray(argumentsValue)) {
-      throw new Error('arguments must be an object');
-    }
-    if (Buffer.byteLength(JSON.stringify(argumentsValue), 'utf8') > MAX_ARGUMENT_BYTES) {
-      throw new Error('arguments too large');
-    }
+    const argumentsValue = normalizeArguments(capabilityId, body.arguments);
 
     const ttlRaw = Number(body.ttlMs);
     const ttlMs = Number.isFinite(ttlRaw)
@@ -297,5 +335,6 @@ function createCompanionCommandRelay(options = {}) {
 
 module.exports = {
   ALLOWED_CAPABILITIES,
+  ALLOWED_APP_ALIASES,
   createCompanionCommandRelay,
 };

--- a/test/companion-command-relay.test.js
+++ b/test/companion-command-relay.test.js
@@ -17,36 +17,24 @@ function createRelay({ agentToken = 'agent-token-abcdefghijklmnopqrstuvwxyz12345
   return {
     relay,
     devices,
-    advance(milliseconds) {
-      clock += milliseconds;
-    },
+    advance(milliseconds) { clock += milliseconds; },
   };
 }
 
 function fakeRequest(authorization) {
   return {
-    get(name) {
-      return name.toLowerCase() === 'authorization' ? authorization || '' : '';
-    },
+    get(name) { return name.toLowerCase() === 'authorization' ? authorization || '' : ''; },
   };
 }
 
 test('agent API is unavailable without a configured agent token', () => {
   const { relay } = createRelay({ agentToken: '' });
-  assert.deepEqual(relay.authorizeAgent(fakeRequest()), {
-    ok: false,
-    status: 503,
-    error: 'agent relay unavailable',
-  });
+  assert.deepEqual(relay.authorizeAgent(fakeRequest()), { ok: false, status: 503, error: 'agent relay unavailable' });
 });
 
 test('agent API rejects an incorrect bearer token', () => {
   const { relay } = createRelay();
-  assert.deepEqual(relay.authorizeAgent(fakeRequest('Bearer wrong-token-wrong-token-wrong-token-wrong-token')), {
-    ok: false,
-    status: 401,
-    error: 'agent authorization required',
-  });
+  assert.deepEqual(relay.authorizeAgent(fakeRequest('Bearer wrong-token-wrong-token-wrong-token-wrong-token')), { ok: false, status: 401, error: 'agent authorization required' });
 });
 
 test('agent API accepts the configured bearer token', () => {
@@ -55,16 +43,61 @@ test('agent API accepts the configured bearer token', () => {
   assert.deepEqual(relay.authorizeAgent(fakeRequest(`Bearer ${token}`)), { ok: true });
 });
 
-test('only read-only capabilities are admitted initially', () => {
+test('high-risk capabilities remain blocked', () => {
   const { relay } = createRelay();
-  assert.throws(
-    () => relay.normalizeCommand({
+  assert.throws(() => relay.normalizeCommand({
+    deviceId: 'device_abcdefghijklmnopqrstuv',
+    requestId: 'request_abcdefghijklmnopqrstuv',
+    capabilityId: 'ui.perform',
+  }), /unsupported capability/);
+});
+
+test('known app opening is admitted only for the bounded alias list', () => {
+  const { relay } = createRelay();
+  const command = relay.normalizeCommand({
+    deviceId: 'device_abcdefghijklmnopqrstuv',
+    requestId: 'request_abcdefghijklmnopqrstuv',
+    capabilityId: 'app.open_known',
+    arguments: { alias: 'maps' },
+  });
+  assert.deepEqual(command.arguments, { alias: 'maps' });
+
+  assert.throws(() => relay.normalizeCommand({
+    deviceId: 'device_abcdefghijklmnopqrstuv',
+    requestId: 'request_zyxwvutsrqponmlkjihgfe',
+    capabilityId: 'app.open_known',
+    arguments: { alias: 'termux' },
+  }), /unsupported app alias/);
+});
+
+test('remote URL opening requires clean HTTPS', () => {
+  const { relay } = createRelay();
+  const command = relay.normalizeCommand({
+    deviceId: 'device_abcdefghijklmnopqrstuv',
+    requestId: 'request_abcdefghijklmnopqrstuv',
+    capabilityId: 'url.open',
+    arguments: { url: 'https://example.com/path' },
+  });
+  assert.equal(command.arguments.url, 'https://example.com/path');
+
+  for (const url of ['http://example.com', 'https://user:pass@example.com/', 'not-a-url']) {
+    assert.throws(() => relay.normalizeCommand({
       deviceId: 'device_abcdefghijklmnopqrstuv',
-      requestId: 'request_abcdefghijklmnopqrstuv',
-      capabilityId: 'ui.perform',
-    }),
-    /unsupported capability/,
-  );
+      requestId: `request_${Buffer.from(url).toString('hex').slice(0, 22).padEnd(22, 'a')}`,
+      capabilityId: 'url.open',
+      arguments: { url },
+    }), /valid https url required/);
+  }
+});
+
+test('read-only capabilities reject unexpected arguments', () => {
+  const { relay } = createRelay();
+  assert.throws(() => relay.normalizeCommand({
+    deviceId: 'device_abcdefghijklmnopqrstuv',
+    requestId: 'request_abcdefghijklmnopqrstuv',
+    capabilityId: 'device.status',
+    arguments: { surprise: true },
+  }), /does not accept arguments/);
 });
 
 test('command moves from queue to inflight to one-time result', () => {
@@ -81,28 +114,15 @@ test('command moves from queue to inflight to one-time result', () => {
   const delivered = relay.takeNext(command.deviceId);
   assert.equal(delivered.requestId, command.requestId);
   assert.equal(delivered.capabilityId, 'device.status');
+  assert.deepEqual(relay.resultStatus(command.requestId), { status: 202, body: { ok: true, requestId: command.requestId, state: 'inflight' } });
 
-  assert.deepEqual(relay.resultStatus(command.requestId), {
-    status: 202,
-    body: { ok: true, requestId: command.requestId, state: 'inflight' },
-  });
-
-  relay.acceptResult(command.deviceId, {
-    requestId: command.requestId,
-    ok: true,
-    data: { batteryPercent: 67 },
-  });
-
+  relay.acceptResult(command.deviceId, { requestId: command.requestId, ok: true, data: { batteryPercent: 67 } });
   const completed = relay.resultStatus(command.requestId);
   assert.equal(completed.status, 200);
   assert.equal(completed.body.ok, true);
   assert.equal(completed.body.commandOk, true);
   assert.deepEqual(completed.body.data, { batteryPercent: 67 });
-
-  assert.deepEqual(relay.resultStatus(command.requestId), {
-    status: 404,
-    body: { ok: false, error: 'request not found' },
-  });
+  assert.deepEqual(relay.resultStatus(command.requestId), { status: 404, body: { ok: false, error: 'request not found' } });
 });
 
 test('duplicate request ids are rejected', () => {
@@ -138,13 +158,9 @@ test('a different device cannot submit a result for an inflight request', () => 
   });
   relay.enqueue(command);
   relay.takeNext(command.deviceId);
-
-  assert.throws(
-    () => relay.acceptResult('device_zyxwvutsrqponmlkjihgfe', {
-      requestId: command.requestId,
-      ok: true,
-      data: {},
-    }),
-    /request is not inflight for this device/,
-  );
+  assert.throws(() => relay.acceptResult('device_zyxwvutsrqponmlkjihgfe', {
+    requestId: command.requestId,
+    ok: true,
+    data: {},
+  }), /request is not inflight for this device/);
 });


### PR DESCRIPTION
## What changed
- expands the direct command relay from `health` / `device.status` to two low-risk owner actions: `app.open_known` and `url.open`
- limits app opening to a fixed alias allowlist
- requires HTTPS URLs with no embedded credentials and bounded length
- keeps `ui.perform`, shell, messaging, Shizuku privilege use, and arbitrary package launch blocked
- adds focused validation tests

This is the next step toward useful hands-free Companion control without opening a general remote-execution surface.