### PR TITLE
Companion relay: add one-time voice authorization challenge

### DIFF
--- a/companion-command-relay.js
+++ b/companion-command-relay.js
@@ -4,7 +4,8 @@ const crypto = require('crypto');
 
 const DEVICE_ID_RE = /^[A-Za-z0-9_-]{22,86}$/;
 const REQUEST_ID_RE = /^[A-Za-z0-9_-]{16,86}$/;
-const ALLOWED_CAPABILITIES = new Set(['health', 'device.status', 'app.open_known', 'url.open']);
+const VOICE_NONCE_RE = /^[A-Za-z0-9_-]{24,128}$/;
+const ALLOWED_CAPABILITIES = new Set(['health', 'device.status', 'app.open_known', 'url.open', 'voice.authorize']);
 const ALLOWED_APP_ALIASES = new Set([
   'settings',
   'chatgpt',
@@ -66,6 +67,12 @@ function normalizeArguments(capabilityId, value) {
       throw new Error('valid https url required');
     }
     return { url: parsed.toString() };
+  }
+
+  if (capabilityId === 'voice.authorize') {
+    const nonce = typeof argumentsValue.nonce === 'string' ? argumentsValue.nonce.trim() : '';
+    if (!VOICE_NONCE_RE.test(nonce)) throw new Error('invalid voice nonce');
+    return { nonce };
   }
 
   throw new Error('unsupported capability');
@@ -336,5 +343,6 @@ function createCompanionCommandRelay(options = {}) {
 module.exports = {
   ALLOWED_CAPABILITIES,
   ALLOWED_APP_ALIASES,
+  VOICE_NONCE_RE,
   createCompanionCommandRelay,
 };

--- a/test/companion-command-relay.test.js
+++ b/test/companion-command-relay.test.js
@@ -90,6 +90,28 @@ test('remote URL opening requires clean HTTPS', () => {
   }
 });
 
+test('voice authorization requires a bounded opaque nonce', () => {
+  const { relay } = createRelay();
+  const nonce = 'voice_nonce_abcdefghijklmnopqrstuv';
+  const command = relay.normalizeCommand({
+    deviceId: 'device_abcdefghijklmnopqrstuv',
+    requestId: 'request_voiceabcdefghijklmnop',
+    capabilityId: 'voice.authorize',
+    arguments: { nonce },
+    ttlMs: 10_000,
+  });
+  assert.deepEqual(command.arguments, { nonce });
+
+  for (const invalid of ['', 'short', 'contains spaces contains spaces']) {
+    assert.throws(() => relay.normalizeCommand({
+      deviceId: 'device_abcdefghijklmnopqrstuv',
+      requestId: 'request_voiceinvalidabcdefgh',
+      capabilityId: 'voice.authorize',
+      arguments: { nonce: invalid },
+    }), /invalid voice nonce/);
+  }
+});
+
 test('read-only capabilities reject unexpected arguments', () => {
   const { relay } = createRelay();
   assert.throws(() => relay.normalizeCommand({


### PR DESCRIPTION
## What changed
- adds internal `voice.authorize` command support to the existing authenticated device queue
- accepts only a bounded opaque nonce argument
- keeps `ui.perform`, shell, messages, arbitrary packages, and privilege use blocked
- adds focused schema tests

## Why
This is the proof-of-possession leg for 3DVR Realtime voice. Companion will create a short-lived local nonce; the Portal sends it back through the authenticated relay; the phone only approves a matching pending nonce before an OpenAI Realtime call is created. No relay credential or OpenAI API key needs to enter Flutter.